### PR TITLE
Link the library MKL SDL to run pardiso_basic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,5 +15,6 @@ find_package(LAPACK REQUIRED)
 find_package(SCALAPACK REQUIRED)
 find_package(MUMPS)
 find_package(METIS)
+find_package(MKL_SDL)
 
 add_subdirectory(src)

--- a/cmake/FindMKL_SDL.cmake
+++ b/cmake/FindMKL_SDL.cmake
@@ -1,0 +1,64 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#[=======================================================================[.rst:
+FindMKL_SDL
+-------
+Cauã Chagas.
+
+Finds the Single Dynamic Library (SDL) of MKL. 
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+MKL_SDL::MKL_SDL
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+``MKL_SDL_FOUND``
+  MKL_SDL libraries were found
+``MKL_SDL_LIBRARIES``
+  MKL_SDL library files
+``MKL_SDL_INCLUDE_DIRS``
+  MKL_SDL include directories
+
+
+#]=======================================================================]
+
+
+find_library(MKL_LIBRARY
+  NAMES "libmkl_rt.so"
+  HINTS ${MKLROOT}
+  PATH_SUFFIXES lib lib/intel64
+  NO_DEFAULT_PATH
+)
+
+find_path(MKL_INCLUDE_DIR
+  NAMES mkl_pardiso.h
+  HINTS ${MKLROOT}
+  PATH_SUFFIXES include
+  NO_DEFAULT_PATH
+)
+
+
+include(FindPackageHandleStandardArgs)
+
+find_package_handle_standard_args(MKL_SDL HANDLE_COMPONENTS
+    REQUIRED_VARS MKL_LIBRARY MKL_INCLUDE_DIR
+)
+
+if(MKL_SDL_FOUND)
+
+  set(HAVE_PARDISO true)
+  set(MKL_SDL_LIBRARIES ${MKL_LIBRARY})
+  set(MKL_SDL_INCLUDE_DIRS ${MKL_INCLUDE_DIR})
+
+  if(NOT TARGET MKL_SDL::MKL_SDL)
+    add_library(MKL_SDL::MKL_SDL INTERFACE IMPORTED)
+    set_property(TARGET MKL_SDL::MKL_SDL PROPERTY INTERFACE_LINK_LIBRARIES "${MKL_SDL_LIBRARIES}")
+    set_property(TARGET MKL_SDL::MKL_SDL PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${MKL_SDL_INCLUDE_DIR}")
+  endif()
+endif(MKL_SDL_FOUND)
+
+mark_as_advanced(MKL_INCLUDE_DIR MKL_LIBRARY)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -69,6 +69,6 @@ HAVE_PARDISO
 
 if(HAVE_PARDISO)
   add_executable(pardiso_basic pardiso_basic.f90)
-  target_link_libraries(pardiso_basic PRIVATE SCALAPACK::SCALAPACK LAPACK::LAPACK)
+  target_link_libraries(pardiso_basic PRIVATE MKL_SDL::MKL_SDL)
   add_test(NAME pardisoBasic COMMAND pardiso_basic)
 endif()


### PR DESCRIPTION
i wrote a simple FindMKL_SDL to run the pardiso_basic example. I used an similar Dockerfile to run the project


```sh
cmake -B build
```

![image](https://user-images.githubusercontent.com/26585248/235544526-14315296-d099-4113-aa0f-04d6cfa1e09b.png)

```sh
cmake -B build -DMKLROOT=$CONDA_PREFIX
```

![image](https://user-images.githubusercontent.com/26585248/235544561-27f898f2-d8e6-4d27-8686-62c0e77b8a72.png)

Examples running

![image](https://user-images.githubusercontent.com/26585248/235544747-6621aeea-bcc0-4064-bb66-14a43a1e75d2.png)



# Ubuntu 22.04 libmkl-rt
I tried changing FindMKL_SDL to work with `libmkl_rt.so` coming from `sudo apt-get install libmkl-rt` on Ubuntu 22.04 but it gives the error

```bash
symbol lookup error: /lib/x86_64-linux-gnu/libmkl_intel_thread.so: undefined symbol: omp_in_parallel
```

I believe this version `libmkl_rt.so` is only compatible with intel compilers.